### PR TITLE
Update requirements & override fetch timeout

### DIFF
--- a/helpers/test/test_entities.py
+++ b/helpers/test/test_entities.py
@@ -14,9 +14,9 @@ class TestEntities(unittest.TestCase):
         story = json.load(open(os.path.join(this_dir, 'fixtures', '2210723002.json')))
         entity_list = entities.from_text(story['story_text'], story['language'])
         if MODEL_MODE == MODEL_MODE_SMALL:
-            assert len(entity_list) == 68
+            assert len(entity_list) == 64
         else:
-            assert len(entity_list) == 50
+            assert len(entity_list) == 60
         for e in entity_list:
             assert 'text' in e
             assert len(e['text']) > 0
@@ -27,9 +27,9 @@ class TestEntities(unittest.TestCase):
         stories = json.load(open(os.path.join(this_dir, 'fixtures', 'ko_sample_stories.json')))
         entity_list = entities.from_text(stories[0], 'ko')
         if MODEL_MODE == MODEL_MODE_SMALL:
-            assert len(entity_list) == 69
+            assert len(entity_list) == 75
         else:
-            assert len(entity_list) == 77
+            assert len(entity_list) == 78
         for e in entity_list:
             assert 'text' in e
             assert len(e['text']) > 0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,9 @@
 requests  # let various other dependencies sort of the right version of this
 python-dotenv==1.0.*
-spacy==3.7.*
+spacy==3.8.*
 pytest==8.*
-sentry-sdk==2.7.*
-fastapi[all]==0.111.*
+sentry-sdk==2.26.*
+fastapi[all]==0.115.*
 uvicorn[standard]  # let pip figure out the right version based on fastapi
-gunicorn==22.0.*
-mediacloud-metadata==1.0.*
+gunicorn==23.0.*
+mediacloud-metadata==1.3.*

--- a/server.py
+++ b/server.py
@@ -48,6 +48,10 @@ else:
     logger.info("Not logging errors to Sentry")
 
 
+# HACK: ovveride mcmetadata timeout to be longer
+mcmetadata.webpages.DEFAULT_TIMEOUT_SECS = 60*5
+
+
 @app.get("/version")
 @api_method
 def version():

--- a/test/test_server.py
+++ b/test/test_server.py
@@ -95,9 +95,9 @@ class TestServer(unittest.TestCase):
         assert 'entities' in data['results']
         assert 'modelMode' in data
         if data['modelMode'] == MODEL_MODE_SMALL:
-            assert len(data['results']['entities']) == 177
+            assert len(data['results']['entities']) == 180
         else:
-            assert len(data['results']['entities']) == 171
+            assert len(data['results']['entities']) == 183
 
     def test_entities_from_url_french(self):
         url = "https://web.archive.org/web/20220407064224/https://www.letelegramme.fr/soir/alain-souchon-j-ai-un-modele-mick-jagger-05-11-2021-12861556.php"
@@ -107,9 +107,9 @@ class TestServer(unittest.TestCase):
         assert 'entities' in data['results']
         assert 'modelMode' in data
         if data['modelMode'] == MODEL_MODE_SMALL:
-            assert len(data['results']['entities']) == 253
+            assert len(data['results']['entities']) == 220
         else:
-            assert len(data['results']['entities']) == 94
+            assert len(data['results']['entities']) == 100
 
     def test_domain_from_url(self):
         response = self._client.post('/content/from-url', data=dict(url=ENGLISH_ARTICLE_URL))
@@ -138,7 +138,10 @@ class TestServer(unittest.TestCase):
         data = response.json()
         assert 'results' in data
         assert 'entities' in data['results']
-        assert len(data['results']['entities']) == 23
+        if data['modelMode'] == MODEL_MODE_SMALL:
+            assert len(data['results']['entities']) == 18
+        else:
+            assert len(data['results']['entities']) == 25
         assert 'domain_name' in data['results']
         assert data['results']['domain_name'] == 'europapress.es'
 


### PR DESCRIPTION
In order to override the fetch timeout we have to update to the latest mcmetadata. So I upgraded all the requirements as a regularly maintenance cleanup job. Review and merge into `main`, then pull into any branch that wants the longer timeout feature (via `mcmetadata.webpages.DEFAULT_TIMEOUT_SECS = 60*5` hack I've included in server.py).